### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -xe
 
-if [[ $1 == "windows" ]] then
+if [[ $1 == "windows" ]]
+then
 	COMPILER="x86_64-w64-mingw32-cc"
 	FLAGS="-mwindows -Wall -Wextra -I./ext/raylib-win/include -L./ext/raylib-win/lib"
 	LIBS="-l:libraylib.a -lwinmm -lgdi32"


### PR DESCRIPTION
fixes 

```
~/github/txt (main) $ ./build.sh
./build.sh: line 4: syntax error near unexpected token `then'
~/github/txt (main) $
```

error on mac

`then` needs to be in a new line or do

```
if [[ $1 == "windows" ]]; then
```

